### PR TITLE
Return vad to allow easy voice activation detection

### DIFF
--- a/src/denoise.rs
+++ b/src/denoise.rs
@@ -74,8 +74,8 @@ impl DenoiseState {
     /// The current output of `process_frame` depends on the current input, but also on the
     /// preceding inputs. Because of this, you might prefer to discard the very first output; it
     /// will contain some fade-in artifacts.
-    pub fn process_frame(&mut self, output: &mut [f32], input: &[f32]) {
-        process_frame(self, output, input);
+    pub fn process_frame(&mut self, output: &mut [f32], input: &[f32]) -> f32 {
+        process_frame(self, output, input)
     }
 }
 


### PR DESCRIPTION
Thanks for creating this library @jneem!
It makes compilation on windows so much better.

The rnnoise library/wrapper returns the vad value, which allows easy voice activation detection. It would be nice to be able to use this with nnnoiseless too.

Also, a `process_frame_in_place` function would be nice, but that’s something else.