### PR TITLE
Initial C API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ autobenches = false
 [lib]
 bench = false
 
+[features]
+capi = ["libc"]
+
 [[bin]]
 name = "munge"
 path = "src/munge.rs"
@@ -25,7 +28,11 @@ harness = false
 num-complex = "0.2.4"
 once_cell = "1.4.0"
 rustfft = "3.0.1"
+libc = { version = "0.2", optional = true }
 
 [dev-dependencies]
 byteorder = "1.3.4"
 criterion = "0.3.3"
+
+[package.metadata.capi]
+header_name = "rnnoise"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![docs]( https://docs.rs/nnnoiseless/badge.svg)](https://docs.rs/nnnoiseless)
 
 `nnnoiseless` is a rust crate for suppressing audio noise. It is a (safe) rust port of
-the [`RNNoise`](https://github.com/xiph/rnnoise) C library, and is based on a recurrent
+the [`RNNoise`][1] C library, and is based on a recurrent
 neural network.
 
 While `nnnoiseless` is meant to be used as a library, a simple command-line
@@ -15,3 +15,15 @@ cargo run --release --example nnnoiseless INPUT.raw OUTPUT.raw
 ```
 
 The output is also a 16-bit raw PCM file.
+
+## C-API
+
+It is possible to install `nnnoiseless` as C-API library, with a [`RNNoise`][1]-compatible header.
+
+``` sh
+# cargo install cargo-c
+# cargo cinstall --destdir /tmp/staging-nnnoiseless
+# sudo cp -a /tmp/staging-nnnoiseless/* /
+```
+
+[1]: https://github.com/xiph/rnnoise

--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -1,0 +1,15 @@
+header = "// SPDX-License-Identifier: BSD-3-Clause"
+sys_includes = ["stdio.h"]
+no_includes = true
+include_guard = "RNNOISE_H"
+tab_width = 4
+style = "Type"
+language = "C"
+cpp_compat = true
+
+[export]
+exclude = ["FRAME_SIZE"]
+
+[const]
+allow_static_const = false
+allow_constexpr = false

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -1,0 +1,109 @@
+use std::boxed::Box;
+use std::os::raw::{c_float, c_int};
+
+use libc::FILE;
+
+pub struct DenoiseState(crate::DenoiseState);
+
+impl Default for DenoiseState {
+    fn default() -> Self {
+        DenoiseState(crate::DenoiseState::default())
+    }
+}
+
+impl DenoiseState {
+    fn boxed() -> Box<DenoiseState> {
+        Box::new(DenoiseState::default())
+    }
+}
+
+pub struct RNNModel(crate::rnn::RnnModel);
+
+/// Return the number of samples processed at time
+///
+/// See `rnnoise_process_frame()`
+#[no_mangle]
+pub unsafe extern "C" fn rnnoise_get_frame_size() -> c_int {
+    crate::DenoiseState::FRAME_SIZE as c_int
+}
+
+/// Return the size of DenoiseState
+///
+/// It should be avoided, use directly `rnnoise_create`
+#[no_mangle]
+pub unsafe extern "C" fn rnnoise_get_size() -> c_int {
+    std::mem::size_of::<DenoiseState>() as c_int
+}
+
+/// Init a pre-allocated DenoiseState
+///
+/// It should be avoided, use directly `rnnoise_create`
+#[no_mangle]
+pub unsafe extern "C" fn rnnoise_init(st: *mut DenoiseState, model: *mut RNNModel) -> c_int {
+    let state = DenoiseState::default();
+
+    if !model.is_null() {
+        todo!("Custom RnnModel model");
+    }
+
+    *st = state;
+
+    0
+}
+
+/// Create and initialize a DenoseState
+///
+/// Use `rnnoise_destroy` to deallocate it
+#[no_mangle]
+pub unsafe extern "C" fn rnnoise_create(model: *mut RNNModel) -> *mut DenoiseState {
+    if !model.is_null() {
+        todo!("Custom RnnModel model");
+    }
+
+    Box::into_raw(DenoiseState::boxed())
+}
+
+/// Deallocate and destroy a DenoiseState
+///
+/// Use it only on pointers returned by `rnnoise_create`.
+#[no_mangle]
+pub unsafe extern "C" fn rnnoise_destroy(st: *mut DenoiseState) {
+    let _ = Box::from_raw(st);
+}
+
+/// Processes a chunk of samples.
+///
+/// It processes `rnnoise_get_frame_size()` samples at time.
+///
+/// The current output of `process_frame` depends on the current input, but also on the
+/// preceding inputs. Because of this, you might prefer to discard the very first output; it
+/// will contain some fade-in artifacts.
+#[no_mangle]
+pub unsafe extern "C" fn rnnoise_process_frame(
+    st: *mut DenoiseState,
+    out: *mut c_float,
+    input: *mut c_float,
+) -> c_float {
+    let state = st.as_mut().expect("Invalid pointer");
+    let output = std::slice::from_raw_parts_mut(out, crate::DenoiseState::FRAME_SIZE);
+    let input = std::slice::from_raw_parts(input, crate::DenoiseState::FRAME_SIZE);
+
+    state.0.process_frame(output, input)
+}
+
+/// Load a Custom Model from file
+///
+/// TODO: unimplemented
+#[no_mangle]
+pub unsafe extern "C" fn rnnoise_model_from_file(file: *mut FILE) -> *mut RNNModel {
+    let _ = file;
+    todo!("Custom Model")
+}
+
+/// Free a Custom Model
+///
+/// See `rnnoise_model_from_file`
+#[no_mangle]
+pub unsafe extern "C" fn rnnoise_model_free(model: *mut RNNModel) {
+    let _ = std::sync::Arc::from_raw(model);
+}

--- a/src/denoise.rs
+++ b/src/denoise.rs
@@ -31,6 +31,7 @@ use crate::{
 ///     first = false;
 /// }
 /// ```
+#[derive(Clone)]
 pub struct DenoiseState {
     /// This stores some of the previous input. Currently, whenever we get new input we shift this
     /// backwards and copy the new input at the end. It might be worth investigating a ring buffer.

--- a/src/denoise.rs
+++ b/src/denoise.rs
@@ -52,9 +52,8 @@ impl DenoiseState {
     /// A `DenoiseState` processes this many samples at a time.
     pub const FRAME_SIZE: usize = FRAME_SIZE;
 
-    /// Creates a new `DenoiseState`.
-    pub fn new() -> Box<DenoiseState> {
-        Box::new(DenoiseState {
+    pub(crate) fn default() -> Self {
+        DenoiseState {
             input_mem: vec![0.0; FRAME_SIZE.max(PITCH_BUF_SIZE)],
             cepstral_mem: [[0.0; NB_BANDS]; CEPS_MEM],
             mem_id: 0,
@@ -63,7 +62,12 @@ impl DenoiseState {
             lastg: [0.0; NB_BANDS],
             rnn: crate::rnn::RnnState::new(),
             pitch_finder: crate::pitch::PitchFinder::new(),
-        })
+        }
+    }
+
+    /// Creates a new `DenoiseState`.
+    pub fn new() -> Box<DenoiseState> {
+        Box::new(Self::default())
     }
 
     // Returns the most recent chunk of input from our internal buffer.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 use once_cell::sync::OnceCell;
 
+#[cfg(any(cargo_c, feature = "capi"))]
+mod capi;
+
 mod denoise;
 mod fft;
 mod model;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ const EBAND_5MS: [usize; 22] = [
     // 0  200 400 600 800  1k 1.2 1.4 1.6  2k 2.4 2.8 3.2  4k 4.8 5.6 6.8  8k 9.6 12k 15.6 20k*/
     0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12, 14, 16, 20, 24, 28, 34, 40, 48, 60, 78, 100,
 ];
-type Complex = num_complex::Complex<f32>;
+type Complex = num_complex::Complex32;
 
 pub(crate) fn compute_band_corr(out: &mut [f32], x: &[Complex], p: &[Complex]) {
     for y in out.iter_mut() {

--- a/src/pitch.rs
+++ b/src/pitch.rs
@@ -1,5 +1,6 @@
 use crate::{PITCH_BUF_SIZE, PITCH_FRAME_SIZE, PITCH_MAX_PERIOD, PITCH_MIN_PERIOD};
 
+#[derive(Clone)]
 pub(crate) struct PitchFinder {
     last_period: usize,
     last_gain: f32,

--- a/src/rnn.rs
+++ b/src/rnn.rs
@@ -85,6 +85,7 @@ pub struct GruLayer {
     pub activation: Activation,
 }
 
+#[derive(Clone)]
 pub struct RnnModel {
     pub input_dense_size: usize,
     pub input_dense: DenseLayer,
@@ -100,6 +101,7 @@ pub struct RnnModel {
     pub vad_output: DenseLayer,
 }
 
+#[derive(Clone)]
 pub struct RnnState {
     model: &'static RnnModel,
     vad_gru_state: Vec<f32>,


### PR DESCRIPTION
It uses [cargo-c](https://github.com/lu-zero/cargo-c) to produce .h, .pc and libraries

- produces a `.h` compatible with the RNNoise API
- produces a `.pc` specific to `nnnoiseless` 
- produces libraries with the same name

- [x] Initial implementation
- [x] Documentation on usage