### PR TITLE
Normalize froward transform using the window energy.

### DIFF
--- a/src/denoise.rs
+++ b/src/denoise.rs
@@ -1,8 +1,8 @@
 use std::borrow::Cow;
 
 use crate::{
-    Complex, RnnModel, CEPS_MEM, FRAME_SIZE, FREQ_SIZE, NB_BANDS, NB_DELTA_CEPS, NB_FEATURES,
-    PITCH_BUF_SIZE, WINDOW_SIZE,
+    common, Complex, RnnModel, CEPS_MEM, FRAME_SIZE, FREQ_SIZE, NB_BANDS, NB_DELTA_CEPS,
+    NB_FEATURES, PITCH_BUF_SIZE, WINDOW_SIZE,
 };
 
 /// This is the main entry-point into `nnnoiseless`. It mainly contains the various memory buffers
@@ -115,7 +115,7 @@ impl<'model> DenoiseState<'model> {
 
         // In the original RNNoise code, the forward transform is normalized and the inverse
         // tranform isn't. `rustfft` doesn't normalize either one, so we do it ourselves.
-        let norm = 1.0 / WINDOW_SIZE as f32;
+        let norm = common().wnorm;
         for x in &mut output[..] {
             *x *= norm;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@ struct CommonState {
     window: [f32; WINDOW_SIZE],
     dct_table: [f32; NB_BANDS * NB_BANDS],
     sin_cos_table: [(f32, f32); WINDOW_SIZE / 2],
+    wnorm: f32,
 }
 
 static COMMON: OnceCell<CommonState> = OnceCell::new();
@@ -91,6 +92,7 @@ fn common() -> &'static CommonState {
             window[i] = (0.5 * pi * sin * sin).sin() as f32;
             window[WINDOW_SIZE - i - 1] = (0.5 * pi * sin * sin).sin() as f32;
         }
+        let wnorm = 1_f32 / window.iter().map(|x| x * x).sum::<f32>();
 
         let mut dct_table = [0.0; NB_BANDS * NB_BANDS];
         for i in 0..NB_BANDS {
@@ -109,6 +111,7 @@ fn common() -> &'static CommonState {
             window,
             dct_table,
             sin_cos_table,
+            wnorm,
         });
     }
     COMMON.get().unwrap()


### PR DESCRIPTION
This ensures that the overall energy between input and output after inverse_transform() is preserved. This can be evaluated by disabling the RNN and pitch filter. The RNN seems to be robust wrt. amplitude changes of the input.

I am not sure about the original RNNoise normalization though.

Some spectrograms:


Input (RMS: 0.003483):
![input](https://user-images.githubusercontent.com/16517898/111772692-70e97580-88ad-11eb-8681-740a4b1a8b4c.png)

No denoised before (the overall power is reduced, RMS: 0.001746):
![nodenoised_before](https://user-images.githubusercontent.com/16517898/111772688-6fb84880-88ad-11eb-91a2-9877294b305a.png)

No denoised now (RMS: 0.003492):
![nodenoised_new](https://user-images.githubusercontent.com/16517898/111772696-71820c00-88ad-11eb-9d9e-5046ea3f74e4.png)

Denoised now (RMS: 0.003012):
![denoised_new](https://user-images.githubusercontent.com/16517898/111772694-71820c00-88ad-11eb-888d-caea2d380561.png)
