### PR TITLE
Compute auto-correlation only on relevant part.

### DIFF
--- a/src/pitch.rs
+++ b/src/pitch.rs
@@ -457,7 +457,7 @@ fn pitch_downsample(x: &[f32], x_lp: &mut [f32]) {
     }
     x_lp[0] = (x[1] / 2.0 + x[0]) / 2.0;
 
-    celt_autocorr(x_lp, &mut ac);
+    celt_autocorr(&x_lp[..(x.len() / 2)], &mut ac);
 
     // Noise floor -40 dB
     ac[0] *= 1.0001;


### PR DESCRIPTION
Since x_lp is already downsampled, we only need the first half.

See: https://github.com/xiph/rnnoise/blob/90ec41ef659fd82cfec2103e9bb7fc235e9ea66c/src/pitch.c#L184

Not a huge performance improvement since this is not a in a performance critical part. But still, the length of x_lp is 1728.