### PR TITLE
Fix training issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ dasp_interpolate = { version = "0.11.0", features = ["sinc"], optional = true }
 dasp_ring_buffer = { version = "0.11.0", optional = true }
 easyfft = "0.3.3"
 glob = { version = "0.3.0", optional = true }
-hdf5 = { version = "0.8.1", optional = true }
+hdf5 = { git = "https://github.com/aldanor/hdf5-rust.git", optional = true }
 hound = { version = "3.4.0", optional = true }
 libc = { version = "0.2.119", optional = true }
 # This needs to be in sync with the version from hdf5; they don't re-export it.

--- a/train/README.md
+++ b/train/README.md
@@ -29,7 +29,7 @@ ffmpeg -i $file -f s16le -ac 1 -ar 48000 output.wav
 Once you have your speech and noise files, you need to use `nnnoiseless` to
 generate training features:
 ```
-cargo run --features=train --bin=train --count=<COUNT> --signal-glob=</PATH/TO/SPEECH/*.wav> --noise-glob=<PATH/TO/NOISE/*.wav> -o training.h5
+cargo run --features=train --bin=train --release -- --count=<COUNT> --signal-glob=</PATH/TO/SPEECH/*.wav> --noise-glob=<PATH/TO/NOISE/*.wav> -o training.h5
 ```
 where `<COUNT>` is the number of frames of training data that you want to
 generate. (I don't know what the optimal number is, but 10 million seems to be


### PR DESCRIPTION
Version 0.8.1 of the hdf5 crate has [issues](https://github.com/aldanor/hdf5-rust/issues/257) that prevent it from compiling with newer versions of hdf5. This pull request switches to the master of hdf5 as the crate maintainers haven't released a new version in over two years.

The training command from `training.md` currently is missing a `--` so the args go to Cargo instead of the training command. I added the dashes and the release flag for convience.

Together these changes make training a model more user-friendly.